### PR TITLE
创建srv_conf，传递上下文

### DIFF
--- a/ngx_http_dyups_module.c
+++ b/ngx_http_dyups_module.c
@@ -1551,6 +1551,10 @@ ngx_dyups_init_upstream(ngx_http_dyups_srv_conf_t *duscf, ngx_str_t *name,
     ctx->main_conf = ((ngx_http_conf_ctx_t *)
                       ngx_cycle->conf_ctx[ngx_http_module.index])->main_conf;
 
+	//ctx 设置
+	cf.ctx = ngx_cycle->conf_ctx[ngx_http_module.index];
+
+
     ctx->srv_conf = ngx_pcalloc(cf.pool, sizeof(void *) * ngx_http_max_module);
     if (ctx->srv_conf == NULL) {
         return NGX_ERROR;


### PR DESCRIPTION
  在使用dyups模块的过程当中，遇到一个问题：

  在ngx_dyups_init_upstream函数中，会调用每个module的create_srv_conf方法创建srv_conf，但是并没有把对应cf的上下文设置好。可能会导致创建方法失败。

  所以我加了代码，传递上下文：
    //ctx 设置

```
cf.ctx = ngx_cycle->conf_ctx[ngx_http_module.index];
```
