### PR TITLE
fix: exit_process segmentfault with dyups off

### DIFF
--- a/ngx_http_dyups_module.c
+++ b/ngx_http_dyups_module.c
@@ -677,6 +677,9 @@ ngx_http_dyups_exit_process(ngx_cycle_t *cycle)
 
     dumcf = ngx_http_cycle_get_module_main_conf(ngx_cycle,
                                                 ngx_http_dyups_module);
+    if (!dumcf) {
+        return;
+    }
 
     duscfs = dumcf->dy_upstreams.elts;
     for (i = 0; i < dumcf->dy_upstreams.nelts; i++) {


### PR DESCRIPTION
Nginx will meet segmentfault with the dyups module added in while not turn the module on during the exit_process. This cause nginx generate core dumps during reload or quit.