### PR TITLE
fix build error when openssl >= 1.1.1c

### DIFF
--- a/ngx_http_dyups_module.c
+++ b/ngx_http_dyups_module.c
@@ -2333,14 +2333,15 @@ ngx_http_dyups_set_peer_session(ngx_peer_connection_t *pc, void *data)
     ssl_session = ctx->ssl_session;
     rc = ngx_ssl_set_session(pc->connection, ssl_session);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "set session: %p", ssl_session);
+
+#else
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "set session: %p:%d", ssl_session,
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
-                   SSL_get_ref(ssl_session)
-#else
-                   ssl_session ? ssl_session->references : 0
+                   ssl_session ? ssl_session->references : 0);
 #endif
-                  );
 
     return rc;
 }
@@ -2359,28 +2360,30 @@ ngx_http_dyups_save_peer_session(ngx_peer_connection_t *pc, void *data)
         return;
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "save session: %p", ssl_session);
+
+#else
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                    "save session: %p:%d", ssl_session,
-#if OPENSSL_VERSION_NUMBER >= 0x10100003L
-                   SSL_get_ref(ssl_session)
-#else
-                   ssl_session->references
+                   ssl_session->references);
 #endif
-                  );
 
     old_ssl_session = ctx->ssl_session;
     ctx->ssl_session = ssl_session;
 
     if (old_ssl_session) {
-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                       "old session: %p:%d",
-                       old_ssl_session,
+
 #if OPENSSL_VERSION_NUMBER >= 0x10100003L
-                       SSL_get_ref(old_ssl_session)
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                       "old session: %p", old_ssl_session);
+
 #else
-                       old_ssl_session->references
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                       "old session: %p:%d", old_ssl_session,
+                       old_ssl_session->references);
 #endif
-                      );
 
         ngx_ssl_free_session(old_ssl_session);
     }


### PR DESCRIPTION
fix build error when openssl >= 1.1.1c, based on https://github.com/alibaba/tengine/pull/1335